### PR TITLE
Don't open Screenshot Manager if F3 is held.

### DIFF
--- a/VoxelCam/src/com/thatapplefreak/voxelcam/VoxelCamCore.java
+++ b/VoxelCam/src/com/thatapplefreak/voxelcam/VoxelCamCore.java
@@ -110,7 +110,7 @@ public class VoxelCamCore implements Tickable, RenderListener, Configurable {
 		// Tell the bigscreenshot taker that the next tick has happend
 		BigScreenshotTaker.onTick();
 		// Check to see if the user wants to open the screenshot manager
-		if (isKeyDown(VoxelCamConfig.KEY_OPENSCREENSHOTMANAGER.getKeyCode())) {
+		if (isKeyDown(VoxelCamConfig.KEY_OPENSCREENSHOTMANAGER.getKeyCode()) && !isKeyDown(KeyBoard.KEY_F3)) {
 			if (!heldKeys.contains(VoxelCamConfig.KEY_OPENSCREENSHOTMANAGER.getKeyCode())) {
 				if (minecraft.currentScreen instanceof GuiMainMenu || minecraft.currentScreen == null) {
 					if (!screenshotIsSaving) {


### PR DESCRIPTION
Should allow uninterrupted use of the F3 debug keys no matter what the keybind is set to. (F3+H)
There's probably a way to do it so if the bound key isn't a debug key, it will open anyway.
