### PR TITLE
Embed capture context into screenshots as PNG metadata

### DIFF
--- a/src/client/java/com/thatapplefreak/voxelcam/client/gui/GuiScreenShotManager.java
+++ b/src/client/java/com/thatapplefreak/voxelcam/client/gui/GuiScreenShotManager.java
@@ -1,5 +1,6 @@
 package com.thatapplefreak.voxelcam.client.gui;
 
+import com.thatapplefreak.voxelcam.client.screenshot.CaptureContext;
 import com.thatapplefreak.voxelcam.client.screenshot.ScreenshotImageCache;
 import com.thatapplefreak.voxelcam.client.screenshot.VoxelCamIO;
 import net.minecraft.ChatFormatting;
@@ -247,6 +248,10 @@ public class GuiScreenShotManager extends Screen {
 			details.append("  ·  ").append(size.width()).append('×').append(size.height());
 		}
 		details.append("  ·  ").append(ScreenshotMetadata.fileSize(selected));
+		CaptureContext captureContext = ScreenshotMetadata.captureContext(selected);
+		if (captureContext != null) {
+			details.append("  ·  ").append(captureContext.describeLocation());
+		}
 		context.centeredText(font,
 				Component.literal(font.plainSubstrByWidth(details.toString(), previewWidth)).withStyle(ChatFormatting.GRAY),
 				previewX + previewWidth / 2, previewY + previewHeight + 4, 0xFFA0A0A0);

--- a/src/client/java/com/thatapplefreak/voxelcam/client/gui/ScreenshotMetadata.java
+++ b/src/client/java/com/thatapplefreak/voxelcam/client/gui/ScreenshotMetadata.java
@@ -1,5 +1,7 @@
 package com.thatapplefreak.voxelcam.client.gui;
 
+import com.thatapplefreak.voxelcam.client.screenshot.CaptureContext;
+import com.thatapplefreak.voxelcam.client.screenshot.PngTextChunk;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -19,6 +21,7 @@ public final class ScreenshotMetadata {
 	}
 
 	private static final Map<File, Dimensions> DIMENSIONS = new HashMap<>();
+	private static final Map<File, CaptureContext> CONTEXTS = new HashMap<>();
 	private static final DateTimeFormatter TIME = DateTimeFormatter.ofPattern("HH:mm");
 	private static final DateTimeFormatter DATE_TIME = DateTimeFormatter.ofPattern("d MMM, HH:mm");
 	private static final DateTimeFormatter FULL = DateTimeFormatter.ofPattern("d MMM yyyy, HH:mm");
@@ -49,8 +52,30 @@ public final class ScreenshotMetadata {
 		}
 	}
 
+	/**
+	 * Reads back the tags {@code CaptureContext.toTags()} writes at capture time, cached the
+	 * same way {@link #dimensions(File)} is. Files captured before this feature shipped, or by
+	 * vanilla F2, or by another mod sharing the folder, simply have no tags — this returns
+	 * null for those rather than a half-built context.
+	 */
+	public static CaptureContext captureContext(File file) {
+		if (file == null) {
+			return null;
+		}
+		CaptureContext cached = CONTEXTS.get(file);
+		if (cached != null) {
+			return cached;
+		}
+		CaptureContext context = CaptureContext.fromTags(PngTextChunk.read(file));
+		if (context != null) {
+			CONTEXTS.put(file, context);
+		}
+		return context;
+	}
+
 	public static void forgetAll() {
 		DIMENSIONS.clear();
+		CONTEXTS.clear();
 	}
 
 	/**

--- a/src/client/java/com/thatapplefreak/voxelcam/client/gui/ScreenshotMetadata.java
+++ b/src/client/java/com/thatapplefreak/voxelcam/client/gui/ScreenshotMetadata.java
@@ -13,6 +13,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /** Cheap, cached file facts shown alongside screenshots. */
 public final class ScreenshotMetadata {
@@ -21,7 +22,7 @@ public final class ScreenshotMetadata {
 	}
 
 	private static final Map<File, Dimensions> DIMENSIONS = new HashMap<>();
-	private static final Map<File, CaptureContext> CONTEXTS = new HashMap<>();
+	private static final Map<File, Optional<CaptureContext>> CONTEXTS = new HashMap<>();
 	private static final DateTimeFormatter TIME = DateTimeFormatter.ofPattern("HH:mm");
 	private static final DateTimeFormatter DATE_TIME = DateTimeFormatter.ofPattern("d MMM, HH:mm");
 	private static final DateTimeFormatter FULL = DateTimeFormatter.ofPattern("d MMM yyyy, HH:mm");
@@ -54,22 +55,22 @@ public final class ScreenshotMetadata {
 
 	/**
 	 * Reads back the tags {@code CaptureContext.toTags()} writes at capture time, cached the
-	 * same way {@link #dimensions(File)} is. Files captured before this feature shipped, or by
-	 * vanilla F2, or by another mod sharing the folder, simply have no tags — this returns
-	 * null for those rather than a half-built context.
+	 * same way {@link #dimensions(File)} is — including the negative case, since unlike
+	 * dimensions() this reads the whole file. Files captured before this feature shipped, or
+	 * by vanilla F2, or by another mod sharing the folder, simply have no tags — this returns
+	 * null for those rather than a half-built context, and caches that so the preview pane
+	 * doesn't re-read the whole file every frame it stays selected.
 	 */
 	public static CaptureContext captureContext(File file) {
 		if (file == null) {
 			return null;
 		}
-		CaptureContext cached = CONTEXTS.get(file);
+		Optional<CaptureContext> cached = CONTEXTS.get(file);
 		if (cached != null) {
-			return cached;
+			return cached.orElse(null);
 		}
 		CaptureContext context = CaptureContext.fromTags(PngTextChunk.read(file));
-		if (context != null) {
-			CONTEXTS.put(file, context);
-		}
+		CONTEXTS.put(file, Optional.ofNullable(context));
 		return context;
 	}
 

--- a/src/client/java/com/thatapplefreak/voxelcam/client/screenshot/CaptureContext.java
+++ b/src/client/java/com/thatapplefreak/voxelcam/client/screenshot/CaptureContext.java
@@ -1,0 +1,98 @@
+package com.thatapplefreak.voxelcam.client.screenshot;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ServerData;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.server.IntegratedServer;
+import net.minecraft.core.BlockPos;
+
+/**
+ * Where a screenshot was taken: dimension, coordinates, and world/server identity. Embedded
+ * into the file itself as PNG text chunks (see {@link PngTextChunk}) rather than a sidecar,
+ * so it survives rename, copy, and share — {@code VoxelCamIO.rename()}/{@code delete()} only
+ * ever touch the PNG, and a sidecar keyed by filename would silently orphan on rename and
+ * leak on delete.
+ */
+public record CaptureContext(String dimension, int x, int y, int z, String worldName) {
+
+	private static final String DIMENSION_KEY = "voxelcam:dimension";
+	private static final String X_KEY = "voxelcam:x";
+	private static final String Y_KEY = "voxelcam:y";
+	private static final String Z_KEY = "voxelcam:z";
+	private static final String WORLD_KEY = "voxelcam:world";
+
+	/**
+	 * @return null if there is no player to read a position from — capturing from the title
+	 * screen, where the manager is also reachable, has no world at all.
+	 */
+	public static CaptureContext capture() {
+		Minecraft client = Minecraft.getInstance();
+		LocalPlayer player = client.player;
+		if (player == null || player.level() == null) {
+			return null;
+		}
+
+		BlockPos pos = player.blockPosition();
+		String dimension = player.level().dimension().identifier().toString();
+		return new CaptureContext(dimension, pos.getX(), pos.getY(), pos.getZ(), worldName(client));
+	}
+
+	/**
+	 * The singleplayer world's own display name, or the multiplayer server list entry's name.
+	 * Deliberately not the server's address: that would bake a real leak into a file a share
+	 * flow might later upload.
+	 */
+	private static String worldName(Minecraft client) {
+		if (client.hasSingleplayerServer()) {
+			IntegratedServer server = client.getSingleplayerServer();
+			return server != null ? server.getWorldData().getLevelName() : null;
+		}
+		ServerData server = client.getCurrentServer();
+		return server != null ? server.name : null;
+	}
+
+	public Map<String, String> toTags() {
+		Map<String, String> tags = new LinkedHashMap<>();
+		tags.put(DIMENSION_KEY, dimension);
+		tags.put(X_KEY, Integer.toString(x));
+		tags.put(Y_KEY, Integer.toString(y));
+		tags.put(Z_KEY, Integer.toString(z));
+		if (worldName != null && !worldName.isEmpty()) {
+			tags.put(WORLD_KEY, worldName);
+		}
+		return tags;
+	}
+
+	/**
+	 * @return null rather than a half-built record if the required tags are missing or
+	 * unparsable — every screenshot taken before this feature shipped (and anything from
+	 * vanilla F2 or another mod sharing the folder) has no tags at all.
+	 */
+	public static CaptureContext fromTags(Map<String, String> tags) {
+		String dimension = tags.get(DIMENSION_KEY);
+		if (dimension == null) {
+			return null;
+		}
+		try {
+			int x = Integer.parseInt(tags.get(X_KEY));
+			int y = Integer.parseInt(tags.get(Y_KEY));
+			int z = Integer.parseInt(tags.get(Z_KEY));
+			return new CaptureContext(dimension, x, y, z, tags.get(WORLD_KEY));
+		} catch (NumberFormatException | NullPointerException e) {
+			return null;
+		}
+	}
+
+	/** e.g. {@code "123, 64, -45"} for the overworld, {@code "the_nether -32, 70, 12"} otherwise. */
+	public String describeLocation() {
+		String coords = x + ", " + y + ", " + z;
+		if ("minecraft:overworld".equals(dimension)) {
+			return coords;
+		}
+		int colon = dimension.indexOf(':');
+		String shortDimension = colon >= 0 ? dimension.substring(colon + 1) : dimension;
+		return shortDimension + " " + coords;
+	}
+}

--- a/src/client/java/com/thatapplefreak/voxelcam/client/screenshot/PngTextChunk.java
+++ b/src/client/java/com/thatapplefreak/voxelcam/client/screenshot/PngTextChunk.java
@@ -1,0 +1,175 @@
+package com.thatapplefreak.voxelcam.client.screenshot;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.zip.CRC32;
+
+/**
+ * Splices {@code iTXt} chunks into an already-encoded PNG and reads them back. {@code
+ * NativeImage.writeToFile} is the STB-backed encoder and only ever emits {@code
+ * IHDR}/{@code IDAT}/{@code IEND}, so embedding metadata means a post-write byte splice
+ * rather than a re-encode — this operates on the file {@code NativeImage} already wrote.
+ *
+ * <p>{@code iTXt} rather than the simpler {@code tEXt}: {@code tEXt} is Latin-1 only, and a
+ * world or server name is exactly the kind of value that might not be. Every chunk this
+ * class writes is uncompressed, with an empty language tag and translated keyword — the
+ * simplest legal {@code iTXt} shape.
+ */
+public final class PngTextChunk {
+
+	private static final byte[] SIGNATURE = { (byte) 0x89, 'P', 'N', 'G', '\r', '\n', 0x1A, '\n' };
+	private static final byte[] ITXT = "iTXt".getBytes(StandardCharsets.US_ASCII);
+	private static final String IEND = "IEND";
+
+	private PngTextChunk() {
+	}
+
+	/** Rewrites {@code file} in place, atomically, with one {@code iTXt} chunk per entry. */
+	public static void embed(File file, Map<String, String> entries) throws IOException {
+		if (entries.isEmpty()) {
+			return;
+		}
+		byte[] spliced = embed(Files.readAllBytes(file.toPath()), entries);
+
+		Path target = file.toPath();
+		Path tmp = Files.createTempFile(target.toAbsolutePath().getParent(), "voxelcam-", ".png.tmp");
+		try {
+			Files.write(tmp, spliced);
+			Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+		} finally {
+			Files.deleteIfExists(tmp);
+		}
+	}
+
+	public static Map<String, String> read(File file) {
+		try {
+			return read(Files.readAllBytes(file.toPath()));
+		} catch (IOException | RuntimeException e) {
+			return Map.of();
+		}
+	}
+
+	/** Package-private seam: pure bytes in, bytes out, no file I/O to stub in a test. */
+	static byte[] embed(byte[] png, Map<String, String> entries) {
+		int insertAt = ihdrEnd(png);
+
+		ByteArrayOutputStream out = new ByteArrayOutputStream(png.length + 64 * entries.size());
+		out.write(png, 0, insertAt);
+		for (Map.Entry<String, String> entry : entries.entrySet()) {
+			out.writeBytes(iTXtChunk(entry.getKey(), entry.getValue()));
+		}
+		out.write(png, insertAt, png.length - insertAt);
+		return out.toByteArray();
+	}
+
+	/** Package-private seam, mirrored with {@link #embed(byte[], Map)}. */
+	static Map<String, String> read(byte[] png) {
+		Map<String, String> tags = new LinkedHashMap<>();
+		int pos = SIGNATURE.length;
+		while (pos + 12 <= png.length) {
+			int length = readInt(png, pos);
+			String type = new String(png, pos + 4, 4, StandardCharsets.US_ASCII);
+			int dataStart = pos + 8;
+			long dataEnd = (long) dataStart + length;
+			if (dataEnd + 4 > png.length) {
+				break; // truncated or corrupt; stop rather than read past the array
+			}
+			if ("iTXt".equals(type)) {
+				readITXt(png, dataStart, (int) dataEnd, tags);
+			} else if (IEND.equals(type)) {
+				break;
+			}
+			pos = (int) dataEnd + 4;
+		}
+		return tags;
+	}
+
+	/** The first chunk after the signature must be IHDR; this is where new chunks are inserted. */
+	private static int ihdrEnd(byte[] png) {
+		int dataLength = readInt(png, SIGNATURE.length);
+		return SIGNATURE.length + 4 + 4 + dataLength + 4;
+	}
+
+	private static byte[] iTXtChunk(String keyword, String text) {
+		byte[] keywordBytes = keyword.getBytes(StandardCharsets.US_ASCII);
+		byte[] textBytes = text.getBytes(StandardCharsets.UTF_8);
+
+		ByteArrayOutputStream data = new ByteArrayOutputStream(keywordBytes.length + textBytes.length + 5);
+		data.writeBytes(keywordBytes);
+		data.write(0); // keyword null separator
+		data.write(0); // compression flag: uncompressed
+		data.write(0); // compression method: unused when uncompressed
+		data.write(0); // empty language tag, null-terminated
+		data.write(0); // empty translated keyword, null-terminated
+		data.writeBytes(textBytes);
+		byte[] chunkData = data.toByteArray();
+
+		CRC32 crc = new CRC32();
+		crc.update(ITXT);
+		crc.update(chunkData);
+
+		ByteArrayOutputStream chunk = new ByteArrayOutputStream(12 + chunkData.length);
+		chunk.writeBytes(intBytes(chunkData.length));
+		chunk.writeBytes(ITXT);
+		chunk.writeBytes(chunkData);
+		chunk.writeBytes(intBytes((int) crc.getValue()));
+		return chunk.toByteArray();
+	}
+
+	private static void readITXt(byte[] png, int start, int end, Map<String, String> tags) {
+		int keywordEnd = indexOf(png, start, end, (byte) 0);
+		if (keywordEnd < 0) {
+			return;
+		}
+		String keyword = new String(png, start, keywordEnd - start, StandardCharsets.US_ASCII);
+
+		int p = keywordEnd + 1;
+		if (p + 2 > end) {
+			return;
+		}
+		boolean compressed = png[p] != 0;
+		p += 2; // compression flag, compression method
+
+		int languageEnd = indexOf(png, p, end, (byte) 0);
+		if (languageEnd < 0) {
+			return;
+		}
+		p = languageEnd + 1;
+
+		int translatedEnd = indexOf(png, p, end, (byte) 0);
+		if (translatedEnd < 0) {
+			return;
+		}
+		p = translatedEnd + 1;
+
+		if (compressed) {
+			return; // this class never writes a compressed chunk; skip anything it doesn't understand.
+		}
+		tags.put(keyword, new String(png, p, end - p, StandardCharsets.UTF_8));
+	}
+
+	private static int indexOf(byte[] data, int from, int to, byte target) {
+		for (int i = from; i < to; i++) {
+			if (data[i] == target) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	private static int readInt(byte[] data, int at) {
+		return ((data[at] & 0xFF) << 24) | ((data[at + 1] & 0xFF) << 16)
+				| ((data[at + 2] & 0xFF) << 8) | (data[at + 3] & 0xFF);
+	}
+
+	private static byte[] intBytes(int value) {
+		return new byte[] { (byte) (value >>> 24), (byte) (value >>> 16), (byte) (value >>> 8), (byte) value };
+	}
+}

--- a/src/client/java/com/thatapplefreak/voxelcam/client/screenshot/ScreenshotHandler.java
+++ b/src/client/java/com/thatapplefreak/voxelcam/client/screenshot/ScreenshotHandler.java
@@ -67,22 +67,40 @@ public final class ScreenshotHandler {
 			screenshotsDir.mkdirs();
 		}
 		File target = ScreenshotNamer.getScreenshotName(screenshotsDir);
+		// Read while still on the render thread: by the time write() runs on the IO pool,
+		// the player may have moved on to a different frame's state entirely.
+		CaptureContext context = CaptureContext.capture();
 
 		// This runs on the render thread, where encoding an oversized PNG would stall the game
 		// for seconds. The saving flag stays up until the write is actually finished.
-		Util.ioPool().execute(() -> write(image, target));
+		Util.ioPool().execute(() -> write(image, target, context));
 	}
 
-	private static void write(NativeImage image, File target) {
+	private static void write(NativeImage image, File target, CaptureContext context) {
 		Minecraft client = Minecraft.getInstance();
 		try (image) {
 			image.writeToFile(target);
+			if (context != null) {
+				embedContext(target, context);
+			}
 			client.execute(() -> ChatMessages.send("voxelcam.savedscreenshotas", target.getName()));
 		} catch (IOException e) {
 			VoxelCamClient.LOGGER.error("Failed to save screenshot to {}", target, e);
 			client.execute(() -> ChatMessages.send("voxelcam.savefailed"));
 		} finally {
 			saving = false;
+		}
+	}
+
+	/**
+	 * The screenshot itself is already saved and good at this point; losing the tag is a
+	 * shame, not a failure worth surfacing to the player the way a failed save is.
+	 */
+	private static void embedContext(File target, CaptureContext context) {
+		try {
+			PngTextChunk.embed(target, context.toTags());
+		} catch (IOException e) {
+			VoxelCamClient.LOGGER.error("Failed to embed capture context into {}", target, e);
 		}
 	}
 }

--- a/src/gametest/java/com/thatapplefreak/voxelcam/gametest/CaptureTest.java
+++ b/src/gametest/java/com/thatapplefreak/voxelcam/gametest/CaptureTest.java
@@ -2,6 +2,8 @@ package com.thatapplefreak.voxelcam.gametest;
 
 import com.thatapplefreak.voxelcam.client.screenshot.BigScreenshot;
 import com.thatapplefreak.voxelcam.client.screenshot.BigScreenshotSize;
+import com.thatapplefreak.voxelcam.client.screenshot.CaptureContext;
+import com.thatapplefreak.voxelcam.client.screenshot.PngTextChunk;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -46,6 +48,7 @@ public class CaptureTest implements FabricClientGameTest {
 
 	private static void assertOrdinaryCaptureWritesAFile(ClientGameTestContext context, File dir) {
 		Set<String> before = listing(dir);
+		Location expected = playerLocation(context);
 
 		context.runOnClient(client ->
 				Screenshot.grab(client.gameDirectory, client.gameRenderer.mainRenderTarget(), message -> { }));
@@ -58,6 +61,35 @@ public class CaptureTest implements FabricClientGameTest {
 		if (!size.equals(window)) {
 			throw new AssertionError("ordinary capture should match the window " + window + ", was " + size);
 		}
+
+		assertCaptureContextMatches(written, expected);
+	}
+
+	/**
+	 * The context is read on the render thread inside {@code ScreenshotHandler.saveCapturedImage},
+	 * before the frame is handed to the IO worker for encoding, so it should match wherever the
+	 * player actually was at capture time.
+	 */
+	private static void assertCaptureContextMatches(File written, Location expected) {
+		CaptureContext embedded = CaptureContext.fromTags(PngTextChunk.read(written));
+		if (embedded == null) {
+			throw new AssertionError("capture should have embedded a capture context, had none");
+		}
+		if (!embedded.dimension().equals(expected.dimension())
+				|| embedded.x() != expected.x() || embedded.y() != expected.y() || embedded.z() != expected.z()) {
+			throw new AssertionError("embedded capture context should be " + expected + ", was " + embedded);
+		}
+	}
+
+	private static Location playerLocation(ClientGameTestContext context) {
+		return context.computeOnClient(client -> {
+			var pos = client.player.blockPosition();
+			return new Location(client.player.level().dimension().identifier().toString(),
+					pos.getX(), pos.getY(), pos.getZ());
+		});
+	}
+
+	private record Location(String dimension, int x, int y, int z) {
 	}
 
 	/**
@@ -68,6 +100,7 @@ public class CaptureTest implements FabricClientGameTest {
 	private static void assertOversizedCaptureMatchesTheRequest(ClientGameTestContext context, File dir) {
 		Dimensions window = windowSize(context);
 		Set<String> before = listing(dir);
+		Location expectedLocation = playerLocation(context);
 
 		context.runOnClient(client -> {
 			BigScreenshot.setSize(BigScreenshotSize.parse("2x"));
@@ -85,6 +118,8 @@ public class CaptureTest implements FabricClientGameTest {
 			throw new AssertionError("2x capture of a " + window + " window should be "
 					+ expected + ", was " + size);
 		}
+
+		assertCaptureContextMatches(written, expectedLocation);
 	}
 
 	/**

--- a/src/test/java/com/thatapplefreak/voxelcam/client/gui/ScreenshotMetadataTest.java
+++ b/src/test/java/com/thatapplefreak/voxelcam/client/gui/ScreenshotMetadataTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.thatapplefreak.voxelcam.client.screenshot.CaptureContext;
+import com.thatapplefreak.voxelcam.client.screenshot.PngTextChunk;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -11,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Map;
 import java.util.zip.CRC32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -152,6 +155,30 @@ class ScreenshotMetadataTest {
 
 		String label = ScreenshotMetadata.relativeTime(file);
 		assertTrue(label.matches("\\d+ \\w+, \\d{2}:\\d{2}"), label);
+	}
+
+	@Test
+	void readsCaptureContextEmbeddedByPngTextChunk() throws IOException {
+		File file = png("shot.png", 640, 480);
+		CaptureContext embedded = new CaptureContext("minecraft:the_nether", 12, 70, -45, "New World");
+		PngTextChunk.embed(file, embedded.toTags());
+
+		assertEquals(embedded, ScreenshotMetadata.captureContext(file));
+	}
+
+	/** Every screenshot taken before this feature shipped has no tags at all. */
+	@Test
+	void captureContextIsNullWhenThereAreNoTags() throws IOException {
+		assertNull(ScreenshotMetadata.captureContext(png("untagged.png", 100, 100)));
+		assertNull(ScreenshotMetadata.captureContext(null));
+	}
+
+	@Test
+	void captureContextSurvivesACorruptOrUnrelatedTag() throws IOException {
+		File file = png("partial.png", 100, 100);
+		PngTextChunk.embed(file, Map.of("voxelcam:dimension", "minecraft:overworld", "some:other:tag", "x"));
+
+		assertNull(ScreenshotMetadata.captureContext(file));
 	}
 
 	/** Nothing here should depend on the platform default charset. */

--- a/src/test/java/com/thatapplefreak/voxelcam/client/screenshot/CaptureContextTest.java
+++ b/src/test/java/com/thatapplefreak/voxelcam/client/screenshot/CaptureContextTest.java
@@ -1,0 +1,71 @@
+package com.thatapplefreak.voxelcam.client.screenshot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link CaptureContext#capture()} needs a live {@code Minecraft} instance and is covered by
+ * the gametest suite instead; this pins the tag encoding/decoding, which is what every
+ * screenshot taken before this feature shipped, or by vanilla F2, has to degrade gracefully
+ * against.
+ */
+class CaptureContextTest {
+
+	@Test
+	void roundTripsThroughTags() {
+		CaptureContext context = new CaptureContext("minecraft:the_nether", 12, 70, -45, "New World");
+
+		assertEquals(context, CaptureContext.fromTags(context.toTags()));
+	}
+
+	@Test
+	void worldNameIsOmittedFromTagsWhenAbsent() {
+		CaptureContext context = new CaptureContext("minecraft:overworld", 0, 64, 0, null);
+
+		assertEquals(Map.of(
+				"voxelcam:dimension", "minecraft:overworld",
+				"voxelcam:x", "0",
+				"voxelcam:y", "64",
+				"voxelcam:z", "0"),
+				context.toTags());
+	}
+
+	@Test
+	void fromTagsIsNullWhenDimensionIsMissing() {
+		assertNull(CaptureContext.fromTags(Map.of("voxelcam:x", "1", "voxelcam:y", "2", "voxelcam:z", "3")));
+	}
+
+	@Test
+	void fromTagsIsNullWhenCoordinatesAreMissingOrUnparsable() {
+		assertNull(CaptureContext.fromTags(Map.of("voxelcam:dimension", "minecraft:overworld")));
+		assertNull(CaptureContext.fromTags(Map.of(
+				"voxelcam:dimension", "minecraft:overworld",
+				"voxelcam:x", "not a number",
+				"voxelcam:y", "2",
+				"voxelcam:z", "3")));
+	}
+
+	@Test
+	void fromTagsIsNullForAnEmptyMap() {
+		assertNull(CaptureContext.fromTags(Map.of()));
+	}
+
+	@Test
+	void describesLocationWithoutTheDimensionInTheOverworld() {
+		CaptureContext context = new CaptureContext("minecraft:overworld", 123, 64, -45, null);
+
+		assertEquals("123, 64, -45", context.describeLocation());
+	}
+
+	@Test
+	void describesLocationWithAShortDimensionNameElsewhere() {
+		CaptureContext nether = new CaptureContext("minecraft:the_nether", 12, 70, -8, null);
+		assertEquals("the_nether 12, 70, -8", nether.describeLocation());
+
+		CaptureContext modded = new CaptureContext("somemod:mining_dimension", 1, 2, 3, null);
+		assertEquals("mining_dimension 1, 2, 3", modded.describeLocation());
+	}
+}

--- a/src/test/java/com/thatapplefreak/voxelcam/client/screenshot/PngTextChunkTest.java
+++ b/src/test/java/com/thatapplefreak/voxelcam/client/screenshot/PngTextChunkTest.java
@@ -1,0 +1,156 @@
+package com.thatapplefreak.voxelcam.client.screenshot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.zip.CRC32;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The splice has to produce a PNG every other reader still opens fine — a wrong chunk
+ * offset or a bad CRC breaks the file for everyone, not just VoxelCam — so this pins the
+ * byte layout, not just the round trip through VoxelCam's own reader.
+ */
+class PngTextChunkTest {
+
+	@TempDir
+	Path dir;
+
+	/** A minimal but real PNG: signature, IHDR, an empty IDAT, IEND. Good enough to splice into. */
+	private static byte[] minimalPng() {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		out.writeBytes(new byte[] { (byte) 0x89, 'P', 'N', 'G', '\r', '\n', 0x1A, '\n' });
+		out.writeBytes(chunk("IHDR", ihdrData(64, 32)));
+		out.writeBytes(chunk("IDAT", new byte[0]));
+		out.writeBytes(chunk("IEND", new byte[0]));
+		return out.toByteArray();
+	}
+
+	private static byte[] ihdrData(int width, int height) {
+		byte[] data = new byte[13];
+		writeInt(data, 0, width);
+		writeInt(data, 4, height);
+		data[8] = 8;
+		data[9] = 2;
+		return data;
+	}
+
+	private static byte[] chunk(String type, byte[] data) {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		writeInt4(out, data.length);
+		byte[] typeBytes = type.getBytes(StandardCharsets.US_ASCII);
+		out.writeBytes(typeBytes);
+		out.writeBytes(data);
+		CRC32 crc = new CRC32();
+		crc.update(typeBytes);
+		crc.update(data);
+		writeInt4(out, (int) crc.getValue());
+		return out.toByteArray();
+	}
+
+	private static void writeInt(byte[] target, int at, int value) {
+		target[at] = (byte) (value >>> 24);
+		target[at + 1] = (byte) (value >>> 16);
+		target[at + 2] = (byte) (value >>> 8);
+		target[at + 3] = (byte) value;
+	}
+
+	private static void writeInt4(ByteArrayOutputStream out, int value) {
+		out.writeBytes(new byte[] { (byte) (value >>> 24), (byte) (value >>> 16), (byte) (value >>> 8), (byte) value });
+	}
+
+	@Test
+	void roundTripsASingleEntry() {
+		Map<String, String> entries = Map.of("voxelcam:dimension", "minecraft:overworld");
+
+		byte[] spliced = PngTextChunk.embed(minimalPng(), entries);
+
+		assertEquals(entries, PngTextChunk.read(spliced));
+	}
+
+	@Test
+	void roundTripsMultipleEntriesInOrder() {
+		Map<String, String> entries = new LinkedHashMap<>();
+		entries.put("voxelcam:dimension", "minecraft:the_nether");
+		entries.put("voxelcam:x", "12");
+		entries.put("voxelcam:y", "70");
+		entries.put("voxelcam:z", "-45");
+		entries.put("voxelcam:world", "New World");
+
+		byte[] spliced = PngTextChunk.embed(minimalPng(), entries);
+
+		assertEquals(entries, PngTextChunk.read(spliced));
+	}
+
+	@Test
+	void survivesNonLatin1TextUnlikeATextChunkWould() {
+		Map<String, String> entries = Map.of("voxelcam:world", "café–base");
+
+		byte[] spliced = PngTextChunk.embed(minimalPng(), entries);
+
+		assertEquals(entries, PngTextChunk.read(spliced));
+	}
+
+	@Test
+	void insertsImmediatelyAfterIhdrNotAtTheEnd() {
+		byte[] original = minimalPng();
+		byte[] spliced = PngTextChunk.embed(original, Map.of("voxelcam:x", "1"));
+
+		// signature (8) + IHDR chunk (4 len + 4 type + 13 data + 4 crc = 25) = 33
+		int ihdrEnd = 33;
+		assertEquals("iTXt", new String(spliced, ihdrEnd + 4, 4, StandardCharsets.US_ASCII));
+
+		// Everything from the original PNG after IHDR should still be present, unmodified,
+		// just pushed later in the file.
+		byte[] originalTail = new byte[original.length - ihdrEnd];
+		System.arraycopy(original, ihdrEnd, originalTail, 0, originalTail.length);
+		byte[] splicedTail = new byte[originalTail.length];
+		System.arraycopy(spliced, spliced.length - originalTail.length, splicedTail, 0, originalTail.length);
+		assertTrue(java.util.Arrays.equals(originalTail, splicedTail));
+	}
+
+	@Test
+	void readingATruncatedFileGivesAnEmptyMapRatherThanThrowing() {
+		byte[] spliced = PngTextChunk.embed(minimalPng(), Map.of("voxelcam:x", "1"));
+		byte[] truncated = new byte[10];
+		System.arraycopy(spliced, 0, truncated, 0, truncated.length);
+
+		assertEquals(Map.of(), PngTextChunk.read(truncated));
+	}
+
+	@Test
+	void aPngWithNoTagsReadsAsEmpty() {
+		assertEquals(Map.of(), PngTextChunk.read(minimalPng()));
+	}
+
+	@Test
+	void embedIsANoOpForNoEntries() {
+		byte[] original = minimalPng();
+
+		assertTrue(java.util.Arrays.equals(original, PngTextChunk.embed(original, Map.of())));
+	}
+
+	@Test
+	void fileBasedEmbedAndReadRoundTripThroughDisk() throws IOException {
+		var file = dir.resolve("shot.png").toFile();
+		Files.write(file.toPath(), minimalPng());
+		Map<String, String> entries = Map.of("voxelcam:dimension", "minecraft:the_end", "voxelcam:x", "5");
+
+		PngTextChunk.embed(file, entries);
+
+		assertEquals(entries, PngTextChunk.read(file));
+	}
+
+	@Test
+	void readingAMissingFileGivesAnEmptyMapRatherThanThrowing() {
+		assertEquals(Map.of(), PngTextChunk.read(dir.resolve("absent.png").toFile()));
+	}
+}


### PR DESCRIPTION
## Summary

Closes #17. Snapshots dimension, coordinates, and world/server identity on the render thread at capture time (`CaptureContext.capture()`), and splices them into the already-written PNG as `iTXt` chunks (`PngTextChunk`) right after `IHDR` — a post-write byte splice, since `NativeImage.writeToFile` only ever emits `IHDR`/`IDAT`/`IEND`.

This is the foundational piece for the rest of the 2.3 milestone (#18, #19, #20) — they all build on this same chunk mechanism rather than each inventing their own sidecar.

## Why a PNG chunk, not a sidecar

A tag embedded in the file travels through rename/copy/share for free. A sidecar keyed by filename would silently orphan the moment `VoxelCamIO.rename()` runs, and leak on `delete()`.

## Why iTXt, not tEXt

`tEXt` is Latin-1 only. A world or server name is exactly the kind of value that might not be, so this uses the still-simple, still-uncompressed `iTXt` variant instead.

## What's wired up

- `CaptureContext.capture()` reads player position/dimension/world-or-server-name on the render thread, inside `ScreenshotHandler.saveCapturedImage`, before the frame is handed to the IO pool for encoding.
- `ScreenshotHandler.write()` embeds the tags after `image.writeToFile(target)` succeeds. A failure to embed is logged but never fails the screenshot save itself — the file is already good at that point.
- `ScreenshotMetadata.captureContext(File)` reads it back, cached the same way `dimensions()` already is.
- `GuiScreenShotManager`'s preview pane grows a fourth details segment showing the location.
- Both the ordinary and oversized (`BigScreenshot`) capture paths get this for free — they share `ScreenshotHandler.saveCapturedImage`.

## Testing

- `PngTextChunkTest` — pure byte-level round-trip and corruption-resilience tests against the chunk splice (no Minecraft classes).
- `CaptureContextTest` — tag encoding/decoding, including the "missing/unparsable tags degrade to null" case every pre-existing screenshot hits.
- `ScreenshotMetadataTest` — the cached-reader path.
- `CaptureTest` (client game test) — extended to assert the embedded context matches the player's actual position/dimension for both the ordinary and oversized capture, in a live client.

All of `./gradlew build` (unit tests + `runClientGameTest`) passes locally.

## Scope notes / what's deliberately not here

- No mod/shaderpack provenance tag, filter tabs, sort modes, or favorites — those are #18-#20, sequenced after this.
- No UI to toggle this off. Per the original brainstorm's own privacy flag: baking location into a file is fine as long as nothing *uploads* it silently — this issue only covers writing/reading the tag locally. Any future share-flow feature that surfaces this data externally should default off and be a conscious per-export choice; that's out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)