### PR TITLE
Sort modes in the screenshot manager

### DIFF
--- a/src/client/java/com/thatapplefreak/voxelcam/client/gui/GuiScreenShotManager.java
+++ b/src/client/java/com/thatapplefreak/voxelcam/client/gui/GuiScreenShotManager.java
@@ -2,6 +2,7 @@ package com.thatapplefreak.voxelcam.client.gui;
 
 import com.thatapplefreak.voxelcam.client.screenshot.CaptureContext;
 import com.thatapplefreak.voxelcam.client.screenshot.ScreenshotImageCache;
+import com.thatapplefreak.voxelcam.client.screenshot.SortMode;
 import com.thatapplefreak.voxelcam.client.screenshot.VoxelCamIO;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
@@ -28,6 +29,8 @@ public class GuiScreenShotManager extends Screen {
 	private static final int GAP = 6;
 	private static final int BUTTON_HEIGHT = 20;
 	private static final int CONTENT_TOP = 52;
+	/** Wide enough for the longest label ("Dims ↓") at the default GUI scale. */
+	private static final int SORT_BUTTON_WIDTH = 54;
 	/** Preview : list width ratio. */
 	private static final float GOLDEN_RATIO = 1.618034F;
 	/** Below this a row cannot fit its thumbnail and a usable slice of the name. */
@@ -37,6 +40,7 @@ public class GuiScreenShotManager extends Screen {
 
 	private ScreenshotListWidget list;
 	private EditBox searchBar;
+	private Button sortButton;
 	private Button renameButton;
 	private Button deleteButton;
 	private Button shareButton;
@@ -70,11 +74,17 @@ public class GuiScreenShotManager extends Screen {
 		int actionsY = height - MARGIN - BUTTON_HEIGHT;
 		int listBottom = actionsY - GAP;
 
-		searchBar = new EditBox(font, MARGIN, 26, listWidth, 18, Component.translatable("voxelcam.search"));
+		int searchWidth = listWidth - SORT_BUTTON_WIDTH - GAP;
+		searchBar = new EditBox(font, MARGIN, 26, searchWidth, 18, Component.translatable("voxelcam.search"));
 		searchBar.setHint(Component.translatable("voxelcam.search").withStyle(ChatFormatting.DARK_GRAY));
 		searchBar.setValue(searchText);
 		searchBar.setResponder(this::onSearchChanged);
 		addRenderableWidget(searchBar);
+
+		sortButton = addRenderableWidget(Button.builder(Component.translatable(SortMode.current().labelKey()),
+						b -> cycleSort())
+				.bounds(MARGIN + searchWidth + GAP, 26, SORT_BUTTON_WIDTH, 18).build());
+		sortButton.setTooltip(Tooltip.create(Component.translatable("voxelcam.tooltip.sort")));
 
 		list = new ScreenshotListWidget(minecraft, listWidth, listBottom - CONTENT_TOP, CONTENT_TOP, this::onSelected);
 		list.setX(MARGIN);
@@ -129,13 +139,23 @@ public class GuiScreenShotManager extends Screen {
 			return;
 		}
 		searchText = text;
-		VoxelCamIO.updateScreenShotFilesList(screenshotsDir, text);
+		// Only the list contents change while typing, so the search field itself is
+		// left alone and keeps focus and cursor position.
+		refreshFiles();
+	}
+
+	private void cycleSort() {
+		SortMode.setCurrent(SortMode.current().next());
+		sortButton.setMessage(Component.translatable(SortMode.current().labelKey()));
+		refreshFiles();
+	}
+
+	private void refreshFiles() {
+		VoxelCamIO.updateScreenShotFilesList(screenshotsDir, searchText);
 		List<File> files = VoxelCamIO.getScreenShotFiles();
 		if (selected == null || !files.contains(selected)) {
 			selected = files.isEmpty() ? null : files.get(0);
 		}
-		// Only the list contents change while typing, so the search field itself is
-		// left alone and keeps focus and cursor position.
 		list.setScreenshots(files, selected);
 		updateButtonStates();
 	}

--- a/src/client/java/com/thatapplefreak/voxelcam/client/gui/ScreenshotMetadata.java
+++ b/src/client/java/com/thatapplefreak/voxelcam/client/gui/ScreenshotMetadata.java
@@ -1,11 +1,9 @@
 package com.thatapplefreak.voxelcam.client.gui;
 
 import com.thatapplefreak.voxelcam.client.screenshot.CaptureContext;
+import com.thatapplefreak.voxelcam.client.screenshot.PngDimensions;
 import com.thatapplefreak.voxelcam.client.screenshot.PngTextChunk;
-import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -42,15 +40,13 @@ public final class ScreenshotMetadata {
 		if (cached != null) {
 			return cached;
 		}
-		try (DataInputStream in = new DataInputStream(new FileInputStream(file))) {
-			// 8-byte PNG signature, 4-byte chunk length, 4-byte "IHDR", then width/height.
-			in.skipNBytes(16);
-			Dimensions dimensions = new Dimensions(in.readInt(), in.readInt());
-			DIMENSIONS.put(file, dimensions);
-			return dimensions;
-		} catch (IOException | RuntimeException e) {
+		PngDimensions.Dimensions read = PngDimensions.read(file);
+		if (read == null) {
 			return null;
 		}
+		Dimensions dimensions = new Dimensions(read.width(), read.height());
+		DIMENSIONS.put(file, dimensions);
+		return dimensions;
 	}
 
 	/**

--- a/src/client/java/com/thatapplefreak/voxelcam/client/screenshot/PngDimensions.java
+++ b/src/client/java/com/thatapplefreak/voxelcam/client/screenshot/PngDimensions.java
@@ -1,0 +1,29 @@
+package com.thatapplefreak.voxelcam.client.screenshot;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+/** Width/height straight out of the PNG IHDR chunk, without decoding the image. */
+public final class PngDimensions {
+
+	public record Dimensions(int width, int height) {
+	}
+
+	private PngDimensions() {
+	}
+
+	public static Dimensions read(File file) {
+		if (file == null) {
+			return null;
+		}
+		try (DataInputStream in = new DataInputStream(new FileInputStream(file))) {
+			// 8-byte PNG signature, 4-byte chunk length, 4-byte "IHDR", then width/height.
+			in.skipNBytes(16);
+			return new Dimensions(in.readInt(), in.readInt());
+		} catch (IOException | RuntimeException e) {
+			return null;
+		}
+	}
+}

--- a/src/client/java/com/thatapplefreak/voxelcam/client/screenshot/SortMode.java
+++ b/src/client/java/com/thatapplefreak/voxelcam/client/screenshot/SortMode.java
@@ -1,0 +1,64 @@
+package com.thatapplefreak.voxelcam.client.screenshot;
+
+import java.io.File;
+import java.util.Comparator;
+import java.util.Locale;
+
+/**
+ * The four things a screenshot list can be ordered by, each ascending or descending.
+ * Held as an in-memory static default for the client session, the same pattern
+ * {@link BigScreenshot} uses for its capture size — no persisted config.
+ */
+public enum SortMode {
+
+	DATE_NEWEST("date.desc", Comparator.comparingLong(File::lastModified).reversed()),
+	DATE_OLDEST("date.asc", Comparator.comparingLong(File::lastModified)),
+	NAME_A_TO_Z("name.asc", Comparator.comparing(SortMode::lowerName)),
+	NAME_Z_TO_A("name.desc", Comparator.comparing(SortMode::lowerName).reversed()),
+	SIZE_LARGEST("size.desc", Comparator.comparingLong(File::length).reversed()),
+	SIZE_SMALLEST("size.asc", Comparator.comparingLong(File::length)),
+	DIMENSIONS_LARGEST("dimensions.desc", Comparator.comparingLong(SortMode::pixelCount).reversed()),
+	DIMENSIONS_SMALLEST("dimensions.asc", Comparator.comparingLong(SortMode::pixelCount));
+
+	private static volatile SortMode current = DATE_NEWEST;
+
+	private final String labelKey;
+	private final Comparator<File> comparator;
+
+	SortMode(String labelSuffix, Comparator<File> comparator) {
+		this.labelKey = "voxelcam.sort." + labelSuffix;
+		this.comparator = comparator;
+	}
+
+	public Comparator<File> comparator() {
+		return comparator;
+	}
+
+	public String labelKey() {
+		return labelKey;
+	}
+
+	/** Cycles through every mode in a fixed order, for a single toggle button. */
+	public SortMode next() {
+		SortMode[] modes = values();
+		return modes[(ordinal() + 1) % modes.length];
+	}
+
+	public static SortMode current() {
+		return current;
+	}
+
+	public static void setCurrent(SortMode mode) {
+		current = mode;
+	}
+
+	private static String lowerName(File file) {
+		return file.getName().toLowerCase(Locale.ROOT);
+	}
+
+	/** A file whose dimensions can't be read sorts as if it were 0×0. */
+	private static long pixelCount(File file) {
+		PngDimensions.Dimensions dimensions = PngDimensions.read(file);
+		return dimensions == null ? 0 : (long) dimensions.width() * dimensions.height();
+	}
+}

--- a/src/client/java/com/thatapplefreak/voxelcam/client/screenshot/VoxelCamIO.java
+++ b/src/client/java/com/thatapplefreak/voxelcam/client/screenshot/VoxelCamIO.java
@@ -2,7 +2,6 @@ package com.thatapplefreak.voxelcam.client.screenshot;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 
@@ -26,7 +25,7 @@ public final class VoxelCamIO {
 		return selected;
 	}
 
-	/** Lists .png files in the directory, newest first, filtered by a case-insensitive name match. */
+	/** Lists .png files in the directory, ordered by {@link SortMode#current()}, filtered by a case-insensitive name match. */
 	public static void updateScreenShotFilesList(File screenshotsDir, String filter) {
 		File[] filesInDir = screenshotsDir.listFiles();
 		String needle = filter == null ? "" : filter.toLowerCase(Locale.ROOT);
@@ -40,7 +39,7 @@ public final class VoxelCamIO {
 				}
 			}
 		}
-		files.sort(Comparator.comparingLong(File::lastModified).reversed());
+		files.sort(SortMode.current().comparator());
 		screenShotFiles = files;
 	}
 

--- a/src/main/resources/assets/voxelcam/lang/en_us.json
+++ b/src/main/resources/assets/voxelcam/lang/en_us.json
@@ -10,6 +10,16 @@
 
 	"voxelcam.screenshots": "Screenshots",
 	"voxelcam.search": "Search",
+
+	"voxelcam.sort.date.desc": "Date ↓",
+	"voxelcam.sort.date.asc": "Date ↑",
+	"voxelcam.sort.name.asc": "Name ↑",
+	"voxelcam.sort.name.desc": "Name ↓",
+	"voxelcam.sort.size.desc": "Size ↓",
+	"voxelcam.sort.size.asc": "Size ↑",
+	"voxelcam.sort.dimensions.desc": "Dims ↓",
+	"voxelcam.sort.dimensions.asc": "Dims ↑",
+
 	"voxelcam.done": "Done",
 	"voxelcam.rename": "Rename",
 	"voxelcam.delete": "Delete",
@@ -45,6 +55,7 @@
 	"voxelcam.tooltip.link": "Upload to catbox.moe and copy the link — no account needed",
 	"voxelcam.tooltip.copypath": "Copy this screenshot's full path to the clipboard",
 	"voxelcam.tooltip.openfolder": "Open the screenshots folder on your computer",
+	"voxelcam.tooltip.sort": "Change sort order",
 	"voxelcam.tooltip.openmanager": "Open the VoxelCam screenshot manager",
 
 	"voxelcam.delete.title": "Delete screenshot?",

--- a/src/test/java/com/thatapplefreak/voxelcam/client/screenshot/PngDimensionsTest.java
+++ b/src/test/java/com/thatapplefreak/voxelcam/client/screenshot/PngDimensionsTest.java
@@ -1,0 +1,66 @@
+package com.thatapplefreak.voxelcam.client.screenshot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.CRC32;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PngDimensionsTest {
+
+	@TempDir
+	Path dir;
+
+	/** A real PNG header: signature, then an IHDR chunk carrying width and height. */
+	private java.io.File png(String name, int width, int height) throws IOException {
+		byte[] ihdr = new byte[13];
+		writeInt(ihdr, 0, width);
+		writeInt(ihdr, 4, height);
+		ihdr[8] = 8;
+		ihdr[9] = 2;
+
+		byte[] chunk = new byte[8 + ihdr.length + 4];
+		writeInt(chunk, 0, ihdr.length);
+		chunk[4] = 'I';
+		chunk[5] = 'H';
+		chunk[6] = 'D';
+		chunk[7] = 'R';
+		System.arraycopy(ihdr, 0, chunk, 8, ihdr.length);
+		CRC32 crc = new CRC32();
+		crc.update(chunk, 4, 4 + ihdr.length);
+		writeInt(chunk, 8 + ihdr.length, (int) crc.getValue());
+
+		byte[] signature = { (byte) 0x89, 'P', 'N', 'G', '\r', '\n', 0x1A, '\n' };
+		java.io.File file = dir.resolve(name).toFile();
+		try (var out = Files.newOutputStream(file.toPath())) {
+			out.write(signature);
+			out.write(chunk);
+		}
+		return file;
+	}
+
+	private static void writeInt(byte[] target, int at, int value) {
+		target[at] = (byte) (value >>> 24);
+		target[at + 1] = (byte) (value >>> 16);
+		target[at + 2] = (byte) (value >>> 8);
+		target[at + 3] = (byte) value;
+	}
+
+	@Test
+	void readsWidthAndHeightFromTheIhdrChunk() throws IOException {
+		assertEquals(new PngDimensions.Dimensions(1920, 1080), PngDimensions.read(png("shot.png", 1920, 1080)));
+	}
+
+	@Test
+	void unreadableFilesGiveNullRatherThanThrowing() throws IOException {
+		Files.writeString(dir.resolve("bogus.png"), "not a png");
+
+		assertNull(PngDimensions.read(dir.resolve("bogus.png").toFile()));
+		assertNull(PngDimensions.read(dir.resolve("absent.png").toFile()));
+		assertNull(PngDimensions.read(null));
+	}
+}

--- a/src/test/java/com/thatapplefreak/voxelcam/client/screenshot/SortModeTest.java
+++ b/src/test/java/com/thatapplefreak/voxelcam/client/screenshot/SortModeTest.java
@@ -1,0 +1,153 @@
+package com.thatapplefreak.voxelcam.client.screenshot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.CRC32;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * current()/setCurrent() are static, session-wide state — the same kind BigScreenshot
+ * holds for its capture size — so every test restores the default afterwards.
+ */
+class SortModeTest {
+
+	@TempDir
+	Path dir;
+
+	@AfterEach
+	void resetCurrent() {
+		SortMode.setCurrent(SortMode.DATE_NEWEST);
+	}
+
+	private File file(String name, long modifiedAt, long bytes) throws IOException {
+		File file = dir.resolve(name).toFile();
+		Files.write(file.toPath(), new byte[(int) bytes]);
+		assertTrue(file.setLastModified(modifiedAt));
+		return file;
+	}
+
+	/** A real PNG header carrying width and height, for the dimensions modes. */
+	private File png(String name, int width, int height) throws IOException {
+		byte[] ihdr = new byte[13];
+		writeInt(ihdr, 0, width);
+		writeInt(ihdr, 4, height);
+		ihdr[8] = 8;
+		ihdr[9] = 2;
+
+		byte[] chunk = new byte[8 + ihdr.length + 4];
+		writeInt(chunk, 0, ihdr.length);
+		chunk[4] = 'I';
+		chunk[5] = 'H';
+		chunk[6] = 'D';
+		chunk[7] = 'R';
+		System.arraycopy(ihdr, 0, chunk, 8, ihdr.length);
+		CRC32 crc = new CRC32();
+		crc.update(chunk, 4, 4 + ihdr.length);
+		writeInt(chunk, 8 + ihdr.length, (int) crc.getValue());
+
+		byte[] signature = { (byte) 0x89, 'P', 'N', 'G', '\r', '\n', 0x1A, '\n' };
+		File file = dir.resolve(name).toFile();
+		try (var out = Files.newOutputStream(file.toPath())) {
+			out.write(signature);
+			out.write(chunk);
+		}
+		return file;
+	}
+
+	private static void writeInt(byte[] target, int at, int value) {
+		target[at] = (byte) (value >>> 24);
+		target[at + 1] = (byte) (value >>> 16);
+		target[at + 2] = (byte) (value >>> 8);
+		target[at + 3] = (byte) value;
+	}
+
+	private static List<String> sortedNames(List<File> files, SortMode mode) {
+		List<File> copy = new ArrayList<>(files);
+		copy.sort(mode.comparator());
+		return copy.stream().map(File::getName).toList();
+	}
+
+	@Test
+	void sortsByDateInBothDirections() throws IOException {
+		File old = file("old.png", 1_000L, 1);
+		File newest = file("newest.png", 3_000L, 1);
+		File middle = file("middle.png", 2_000L, 1);
+		List<File> files = List.of(old, newest, middle);
+
+		assertEquals(List.of("newest.png", "middle.png", "old.png"), sortedNames(files, SortMode.DATE_NEWEST));
+		assertEquals(List.of("old.png", "middle.png", "newest.png"), sortedNames(files, SortMode.DATE_OLDEST));
+	}
+
+	@Test
+	void sortsByNameCaseInsensitivelyInBothDirections() throws IOException {
+		File banana = file("Banana.png", 1_000L, 1);
+		File apple = file("apple.png", 1_000L, 1);
+		File cherry = file("cherry.png", 1_000L, 1);
+		List<File> files = List.of(banana, apple, cherry);
+
+		assertEquals(List.of("apple.png", "Banana.png", "cherry.png"), sortedNames(files, SortMode.NAME_A_TO_Z));
+		assertEquals(List.of("cherry.png", "Banana.png", "apple.png"), sortedNames(files, SortMode.NAME_Z_TO_A));
+	}
+
+	@Test
+	void sortsByFileSizeInBothDirections() throws IOException {
+		File small = file("small.png", 1_000L, 10);
+		File big = file("big.png", 1_000L, 1000);
+		File medium = file("medium.png", 1_000L, 100);
+		List<File> files = List.of(small, big, medium);
+
+		assertEquals(List.of("big.png", "medium.png", "small.png"), sortedNames(files, SortMode.SIZE_LARGEST));
+		assertEquals(List.of("small.png", "medium.png", "big.png"), sortedNames(files, SortMode.SIZE_SMALLEST));
+	}
+
+	@Test
+	void sortsByPixelAreaInBothDirections() throws IOException {
+		File small = png("small.png", 10, 10);
+		File big = png("big.png", 1000, 1000);
+		File medium = png("medium.png", 100, 100);
+		List<File> files = List.of(small, big, medium);
+
+		assertEquals(List.of("big.png", "medium.png", "small.png"), sortedNames(files, SortMode.DIMENSIONS_LARGEST));
+		assertEquals(List.of("small.png", "medium.png", "big.png"), sortedNames(files, SortMode.DIMENSIONS_SMALLEST));
+	}
+
+	/** Unreadable dimensions must not throw mid-sort — they sort as 0×0 instead. */
+	@Test
+	void filesWithUnreadableDimensionsSortAsSmallest() throws IOException {
+		Files.writeString(dir.resolve("bogus.png"), "not a png");
+		File bogus = dir.resolve("bogus.png").toFile();
+		File real = png("real.png", 10, 10);
+		List<File> files = List.of(bogus, real);
+
+		assertEquals(List.of("real.png", "bogus.png"), sortedNames(files, SortMode.DIMENSIONS_LARGEST));
+	}
+
+	@Test
+	void nextCyclesThroughEveryModeAndWrapsAround() {
+		SortMode mode = SortMode.DATE_NEWEST;
+		for (int i = 0; i < SortMode.values().length - 1; i++) {
+			mode = mode.next();
+		}
+		assertEquals(SortMode.values()[SortMode.values().length - 1], mode);
+		assertSame(SortMode.DATE_NEWEST, mode.next());
+	}
+
+	@Test
+	void currentDefaultsToDateNewestAndCanBeChanged() {
+		assertSame(SortMode.DATE_NEWEST, SortMode.current());
+
+		SortMode.setCurrent(SortMode.NAME_A_TO_Z);
+
+		assertSame(SortMode.NAME_A_TO_Z, SortMode.current());
+	}
+}

--- a/src/test/java/com/thatapplefreak/voxelcam/client/screenshot/VoxelCamIOTest.java
+++ b/src/test/java/com/thatapplefreak/voxelcam/client/screenshot/VoxelCamIOTest.java
@@ -29,6 +29,7 @@ class VoxelCamIOTest {
 	@BeforeEach
 	void reset() {
 		VoxelCamIO.selectPhoto(null);
+		SortMode.setCurrent(SortMode.DATE_NEWEST);
 		VoxelCamIO.updateScreenShotFilesList(dir.toFile(), "");
 	}
 
@@ -69,6 +70,19 @@ class VoxelCamIOTest {
 		VoxelCamIO.updateScreenShotFilesList(dir.toFile(), "");
 
 		assertEquals(List.of("newest.png", "middle.png", "old.png"), names());
+	}
+
+	/** {@link SortMode#current()} is what updateScreenShotFilesList actually sorts by. */
+	@Test
+	void listRespectsTheCurrentSortMode() throws IOException {
+		shot("banana.png", 1_000L);
+		shot("apple.png", 2_000L);
+		shot("cherry.png", 1_500L);
+		SortMode.setCurrent(SortMode.NAME_A_TO_Z);
+
+		VoxelCamIO.updateScreenShotFilesList(dir.toFile(), "");
+
+		assertEquals(List.of("apple.png", "banana.png", "cherry.png"), names());
 	}
 
 	@Test


### PR DESCRIPTION
Closes #18.

## Summary

- Adds `SortMode`: date, name, size, dimensions, each ascending/descending. Held as
  an in-memory static default for the client session — the same pattern
  `BigScreenshot` uses for its capture size, per the issue's implementation sketch.
- A compact button next to the search bar cycles through the 8 modes and re-triggers
  the same filter/select refresh the search box already drives.
- `VoxelCamIO.updateScreenShotFilesList` now sorts with `SortMode.current().comparator()`
  instead of a hardcoded newest-first `Comparator`. Default stays newest-first, so
  existing behavior is unchanged until the button is used.
- Extracted `PngDimensions` (the same IHDR-only read `ScreenshotMetadata.dimensions()`
  already did) into the `screenshot` package so the dimensions modes can read a PNG's
  size without `screenshot` depending on `gui` — `ScreenshotMetadata` now delegates to
  it and keeps its own cache.

## Test plan

- [x] `./gradlew test` — new `SortModeTest` (comparator correctness in both directions
  for all four fields, cycling/wraparound, current/setCurrent), new `PngDimensionsTest`,
  updated `VoxelCamIOTest` (resets `SortMode` between tests, covers a non-default mode
  flowing through the list).
- [x] `./gradlew runClientGameTest` — existing `ScreenshotManagerTest` still opens the
  manager and renders a full frame with the new button present.
- [x] `./gradlew build` — both suites gated, green.